### PR TITLE
Test CI services

### DIFF
--- a/.checkignore
+++ b/.checkignore
@@ -1,0 +1,2 @@
+# QualifiedCode configuration.
+app/test/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
 before_install:
     - pip install -U pip setuptools wheel
 install:
-    # - pip install codacy-coverage
     # - pip install coveralls
     - pip install codecov
     - travis_wait travis_retry pip install -r requirements.txt
@@ -21,15 +20,7 @@ script:
     - cd app/test
     - py.test
 after_success:
-    # coveralls
-    # - codecov
     - bash <(curl -s https://codecov.io/bash) # codecov.io
-      # - coverage xml
-      # - python-codacy-coverage -r coverage.xml
-# --source specifies what packages to cover, you probably want to use that option
-script:
-    - cd app/
-    - coverage run ./app.py
 notifications:
     slack: io-touchpad:Fv8xkXiL4PSbXN8GN9hDAlxp
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,17 @@ before_install:
     - pip install -U pip setuptools wheel
 install:
     # - pip install codacy-coverage
-    - pip install coveralls
-    # - pip install codecov
+    # - pip install coveralls
+    - pip install codecov
     - travis_wait travis_retry pip install -r requirements.txt
     - make
 script:
     - cd app/test
     - py.test
 after_success:
-      coveralls
-#     - codecov
-#     - bash <(curl -s https://codecov.io/bash) # codecov.io
+    # coveralls
+    # - codecov
+    - bash <(curl -s https://codecov.io/bash) # codecov.io
       # - coverage xml
       # - python-codacy-coverage -r coverage.xml
 # --source specifies what packages to cover, you probably want to use that option

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,13 @@ addons:
 before_install:
     - pip install -U pip setuptools wheel pytest-cov
 install:
-    # - pip install coveralls
-    - pip install codecov
     - travis_wait travis_retry pip install -r requirements.txt
     - make
 script:
     - cd app/test
     - py.test --cov=./
+after_success:
+    - bash <(curl -s https://codecov.io/bash)
 notifications:
     slack: io-touchpad:Fv8xkXiL4PSbXN8GN9hDAlxp
     email: false
-after_success:
-    - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
 after_success:
 #     - codecov
 #     - bash <(curl -s https://codecov.io/bash) # codecov.io
+      - coverage xml
       - python-codacy-coverage -r coverage.xml
 notifications:
     slack: io-touchpad:Fv8xkXiL4PSbXN8GN9hDAlxp

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,14 @@ addons:
 before_install:
     - pip install -U pip setuptools wheel
 install:
+    - pip install --user codecov
     - travis_wait travis_retry pip install -r requirements.txt
     - make
 script:
     - cd app/test
     - py.test
 after_success:
+    - codecov
     - bash <(curl -s https://codecov.io/bash) # codecov.io
 notifications:
     slack: io-touchpad:Fv8xkXiL4PSbXN8GN9hDAlxp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 python:
     - "3.4"
     - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ before_install:
 install:
     - travis_wait travis_retry pip install -r requirements.txt
     - make
-after_success:
-    - bash <(curl -s https://codecov.io/bash) # codecov.io
 script:
     - cd app/test
     - py.test
+after_success:
+    - bash <(curl -s https://codecov.io/bash) # codecov.io
 notifications:
     slack: io-touchpad:Fv8xkXiL4PSbXN8GN9hDAlxp
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install:
 install:
     - travis_wait travis_retry pip install -r requirements.txt
     - make
+after_success:
+    - bash <(curl -s https://codecov.io/bash) # codecov.io
 script:
     - cd app/test
     - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
     - "3.4"
     - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ addons:
 before_install:
     - pip install -U pip setuptools wheel
 install:
-    - pip install codacy-coverage
+    # - pip install codacy-coverage
+    - pip install coveralls
     # - pip install codecov
     - travis_wait travis_retry pip install -r requirements.txt
     - make
@@ -20,10 +21,15 @@ script:
     - cd app/test
     - py.test
 after_success:
+      coveralls
 #     - codecov
 #     - bash <(curl -s https://codecov.io/bash) # codecov.io
-      - coverage xml
-      - python-codacy-coverage -r coverage.xml
+      # - coverage xml
+      # - python-codacy-coverage -r coverage.xml
+# --source specifies what packages to cover, you probably want to use that option
+script:
+    - cd app/
+    - coverage run ./app.py
 notifications:
     slack: io-touchpad:Fv8xkXiL4PSbXN8GN9hDAlxp
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,17 @@ addons:
 before_install:
     - pip install -U pip setuptools wheel
 install:
-    - pip install codecov
+    - pip install codacy-coverage
+    # - pip install codecov
     - travis_wait travis_retry pip install -r requirements.txt
     - make
 script:
     - cd app/test
     - py.test
 after_success:
-    - codecov
-    - bash <(curl -s https://codecov.io/bash) # codecov.io
+#     - codecov
+#     - bash <(curl -s https://codecov.io/bash) # codecov.io
+      - python-codacy-coverage -r coverage.xml
 notifications:
     slack: io-touchpad:Fv8xkXiL4PSbXN8GN9hDAlxp
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 before_install:
     - pip install -U pip setuptools wheel
 install:
-    - pip install --user codecov
+    - pip install codecov
     - travis_wait travis_retry pip install -r requirements.txt
     - make
 script:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Build Status](https://travis-ci.org/0mp/io-touchpad.svg?branch=master)](https://travis-ci.org/0mp/io-touchpad)
 [![Code Health](https://landscape.io/github/0mp/io-touchpad/master/landscape.svg?style=flat)](https://landscape.io/github/0mp/io-touchpad/master)
+[![Code Issues](https://www.quantifiedcode.com/api/v1/project/538d6bb306774bd7ae52b8c4dbdd0854/badge.svg)](https://www.quantifiedcode.com/app/project/538d6bb306774bd7ae52b8c4dbdd0854)
+[![codecov](https://codecov.io/gh/0mp/io-touchpad/branch/master/graph/badge.svg)](https://codecov.io/gh/0mp/io-touchpad)
+
 
 ## Application
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Code Health](https://landscape.io/github/0mp/io-touchpad/master/landscape.svg?style=flat)](https://landscape.io/github/0mp/io-touchpad/master)
 [![Code Issues](https://www.quantifiedcode.com/api/v1/project/538d6bb306774bd7ae52b8c4dbdd0854/badge.svg)](https://www.quantifiedcode.com/app/project/538d6bb306774bd7ae52b8c4dbdd0854)
 [![codecov](https://codecov.io/gh/0mp/io-touchpad/branch/master/graph/badge.svg)](https://codecov.io/gh/0mp/io-touchpad)
+[![Codacy Badge](https://api.codacy.com/project/badge/grade/dc3f6a8c83dc4acbab2a195fdfd70008)](https://www.codacy.com/app/mpp302/io-touchpad)
 
 
 ## Application

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Code Health](https://landscape.io/github/0mp/io-touchpad/master/landscape.svg?style=flat)](https://landscape.io/github/0mp/io-touchpad/master)
 [![Code Issues](https://www.quantifiedcode.com/api/v1/project/538d6bb306774bd7ae52b8c4dbdd0854/badge.svg)](https://www.quantifiedcode.com/app/project/538d6bb306774bd7ae52b8c4dbdd0854)
 [![codecov](https://codecov.io/gh/0mp/io-touchpad/branch/master/graph/badge.svg)](https://codecov.io/gh/0mp/io-touchpad)
-[![Codacy Badge](https://api.codacy.com/project/badge/grade/dc3f6a8c83dc4acbab2a195fdfd70008)](https://www.codacy.com/app/mpp302/io-touchpad)
 
 
 ## Application

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,64 @@
+codecov:
+  branch: master       # the branch to show by default, inherited from your git repository settings
+                       # ex. master, stable or release
+                       # default: the default branch in git/mercurial
+  # bot: username        # the username that will consume any oauth requests
+  #                      # must have previously logged into Codecov
+
+coverage:
+  precision: 2         # how many decimal places to display in the UI: 0 <= value <= 4
+  round: down          # how coverage is rounded: down/up/nearest
+  range: 50...100      # custom range of coverage colors from red -> yellow -> green
+
+  notify:
+    slack:
+      default:                        # -> see "sections" below
+        url: "https://hooks.slack.com/services/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"
+        branches: null                # -> see "branch patterns" below
+        threshold: null               # -> see "threshold" below
+        attachments: "sunburst, diff" # list of attachments to include in notification
+        # message: "template string"    # [advanced] -> see "customized message" below
+
+  status:
+    project:                   # measuring the overall project coverage
+      enabled: yes             # must be yes|true to enable this status
+      target: auto             # specify the target coverage for each commit status
+                               #   option: "auto" (must increase from parent commit or pull request base)
+                               #   option: "X%" a static target percentage to hit
+      branches:                # -> see "branch patterns" below
+      threshold: null          # allowed to drop X% and still result in a "success" commit status
+      if_no_uploads: error     # will post commit status of "error" if no coverage reports we uploaded
+                               # options: success, error, failure
+      if_not_found: success    # if parent is not found report status as success, error, or failure
+      if_ci_failed: error      # if ci fails report status as success, error, or failure
+
+    patch:                     # pull requests only: this commit status will measure the
+                               # entire pull requests Coverage Diff. Checking if the lines
+                               # adjusted are covered at least X%.
+      enabled: yes             # must be yes|true to enable this status
+      target: 80%              # specify the target "X%" coverage to hit
+      branches: null           # -> see "branch patterns" below
+      threshold: null          # allowed to drop X% and still result in a "success" commit status
+      if_no_uploads: error     # will post commit status of "error" if no coverage reports we uploaded
+                               # options: success, error, failure
+      if_not_found: success
+      if_ci_failed: error
+
+    changes:                   # if there are any unexpected changes in coverage
+      enabled: yes             # must be yes|true to enable this status
+      branches: null           # -> see "branch patterns" below
+      if_no_uploads: error
+      if_not_found: success
+      if_ci_failed: error
+
+
+  ignore:          # files and folders that will be removed during processing
+    - "app/test/*"
+
+comment:
+  layout: "header, diff, changes, sunburst, suggestions"
+  branches: null           # -> see "branch patterns" below
+  behavior: default        # option: "default" posts once then update, posts new if delete
+                           # option: "once"    post once then updates, if deleted do not post new
+                           # option: "new"     delete old, post new
+                           # option: "spammy"  post new

--- a/sideci.yml
+++ b/sideci.yml
@@ -1,0 +1,2 @@
+flake8:
+    version: 3


### PR DESCRIPTION
I'm testing different CI in this branch.


- ### <strike>Codacy</strike>

 https://www.codacy.com/app/0mp/io-touchpad/dashboard

 Coverage and style.

 It is paid. :/

- ### Codecov

 https://codecov.io/gh/0mp/io-touchpad

 Checks the coverage of our code.

 - These graphs look awesome. Too bad the service is a little bit down now. https://codecov.io/gh/0mp/io-touchpad/branch/master/graphs

- ### SideCI

 Similar to Landscape, but much much faster. It looks like this service checks only diffs instead of the whole repo.

 https://www.sideci.com/github_repositories/54242271/news_feed

- ### QualifiedCode

 https://www.quantifiedcode.com/app/project/538d6bb306774bd7ae52b8c4dbdd0854?tab=badges

 It is a mixture of Travis and Landscape. It looks like a nice service although it is painfully slow.